### PR TITLE
absolute-path-fixes

### DIFF
--- a/src/scenes/level.js
+++ b/src/scenes/level.js
@@ -140,7 +140,10 @@ export class LevelScene extends Phaser.Scene {
 
         // Buy auto clickers
         this.autoClickerButton = this.add
-            .text(20, 50, "50 gold for autoclicker", { font: "20px runescape", fill: "gold" })
+            .text(20, 50, "50 gold for autoclicker", {
+                font: "20px runescape",
+                fill: "gold",
+            })
             .setDepth(3)
             .setInteractive()
             .on("pointerup", () => {
@@ -267,7 +270,7 @@ export class LevelScene extends Phaser.Scene {
                         case EQUIPMENT.ATTACK_STYLE.CRUSH:
                             startX = 450;
                             startY = 200;
-                            break
+                            break;
                         case EQUIPMENT.ATTACK_STYLE.SLASH:
                             curve = 1;
                             startX = 450;
@@ -314,42 +317,46 @@ export class LevelScene extends Phaser.Scene {
 
         // Add animation image
         image = this.add
-                .image(startX, startY, imageName)
-                .setScale(scale)
-                .setDepth(4)
-                .setAlpha(alpha)
-                .setFlipX(flipX);
+            .image(startX, startY, imageName)
+            .setScale(scale)
+            .setDepth(4)
+            .setAlpha(alpha)
+            .setFlipX(flipX);
 
         // Move animation
         let endX = Math.floor(this.width / 2) - 100,
             endY = Math.floor(this.height / 2);
         this.tweens.add({
-                targets: image,
-                x: endX,
-                y: endY,
-                duration: 500,
-                ease: (t) => {
-                    return Math.pow(Math.sin(t * 3), 3);
-                },
-                onComplete: () => {
+            targets: image,
+            x: endX,
+            y: endY,
+            duration: 500,
+            ease: (t) => {
+                return Math.pow(Math.sin(t * 3), 3);
+            },
+            onComplete: () => {
+                image.destroy();
+            },
+            onUpdate: () => {
+                // Destroy if within 1 pixel of end point
+                // Otherwise image will return to origin
+                if (
+                    image.x >= endX - 1 &&
+                    image.x <= endX + 1 &&
+                    image.y >= endY - 1 &&
+                    image.y <= endY + 1
+                ) {
                     image.destroy();
-                },
-                onUpdate: () => {
-                    // Destroy if within 1 pixel of end point
-                    // Otherwise image will return to origin
-                    if ((image.x >= endX - 1 && image.x <= endX + 1) && 
-                        (image.y >= endY - 1 && image.y <= endY + 1)) {
-                        image.destroy();
-                    } else {
-                        image.scale -= 0.005;
-                        image.angle -= curve;
-                        if (image.alpha < 1) {
-                            image.alpha += .03;
-                        }
+                } else {
+                    image.scale -= 0.005;
+                    image.angle -= curve;
+                    if (image.alpha < 1) {
+                        image.alpha += 0.03;
                     }
-                },
-                repeat: 0,
-                delay: 50,
-            });
+                }
+            },
+            repeat: 0,
+            delay: 50,
+        });
     }
 }

--- a/src/scenes/load.js
+++ b/src/scenes/load.js
@@ -15,7 +15,7 @@ export class LoadScene extends Phaser.Scene {
                     {
                         type: "image",
                         key: "lesser-demon",
-                        url: "/src/assets/sprites/LesserDemon.png",
+                        url: "src/assets/sprites/LesserDemon.png",
                     },
                 ],
             },

--- a/src/scenes/main-menu.js
+++ b/src/scenes/main-menu.js
@@ -85,10 +85,7 @@ export class MainMenuScene extends Phaser.Scene {
                 this.scene.start(this.characterData.currentLevel, this.characterData);
                 console.log("Going to", this.characterData.currentLevel);
             } else {
-                this.scene.start(
-                    CONSTANTS.SCENES.TUTORIAL_ISLAND,
-                    this.characterData
-                );
+                this.scene.start(CONSTANTS.SCENES.TUTORIAL_ISLAND, this.characterData);
                 console.log("Going to Tutorial Island");
             }
         });

--- a/src/scenes/shop.js
+++ b/src/scenes/shop.js
@@ -239,7 +239,7 @@ export class ShopScene extends Phaser.Scene {
                 if (itemManifest[item].type == itemType) {
                     // Get item class
                     let path = itemManifest[item].classPath;
-                    let itemClass = await import("/src/items/" + path);
+                    let itemClass = await import("../../src/items/" + path);
                     let newItem = new itemClass.default(this.scrollWindow);
 
                     // Create sprite

--- a/src/targets/resource.js
+++ b/src/targets/resource.js
@@ -18,7 +18,7 @@ export class Resource extends Target {
             this.scene,
             this.x,
             this.y - 40,
-            this.neededClicks,
+            this.neededClicks
         );
     }
 
@@ -27,7 +27,7 @@ export class Resource extends Target {
         if (this.skill == "woodcutting" && curWeapon.item != "Axe") {
             return false;
         } else {
-            return true; true;
+            return true;
         }
     }
 

--- a/src/targets/target.js
+++ b/src/targets/target.js
@@ -65,7 +65,7 @@ export class Target extends ClickableObject {
         if (this.isClickable()) {
             // Click animation
             this.scene.clickAnimation();
-            
+
             // Target click interaction to be implemented by the child
             let progress = this.getClickValue();
             this.onClick(progress);

--- a/src/ui/scroll-window.js
+++ b/src/ui/scroll-window.js
@@ -141,9 +141,13 @@ export class ScrollWindow extends Phaser.Scene {
 
                 // Setup timer to check if scrollheader/footer is being held
                 this.timer = this.time.addEvent({
-                    delay: 100,                // ms
+                    delay: 100, // ms
                     callback: () => {
-                        this.scroll(this.curDelta, remainingScrollBarDist, remainingListDist);
+                        this.scroll(
+                            this.curDelta,
+                            remainingScrollBarDist,
+                            remainingListDist
+                        );
                     },
                     loop: true,
                     paused: true,
@@ -173,7 +177,11 @@ export class ScrollWindow extends Phaser.Scene {
                 this.input.on("drag", (pointer, gameObject, dragX, dragY) => {
                     let drag = dragY - this.scrollButton.y;
                     if (Math.abs(drag) > 5) {
-                        this.scroll(dragY - this.scrollButton.y, remainingScrollBarDist, remainingListDist);
+                        this.scroll(
+                            dragY - this.scrollButton.y,
+                            remainingScrollBarDist,
+                            remainingListDist
+                        );
                     }
                 });
             }
@@ -197,8 +205,7 @@ export class ScrollWindow extends Phaser.Scene {
             }
 
             // Scale scroll bar delta
-            let scrollBarDelta =
-                deltaY * (remainingScrollBarDist / remainingListDist);
+            let scrollBarDelta = deltaY * (remainingScrollBarDist / remainingListDist);
 
             // Check top/bottom bounds
             let scrollButtonHeight = this.scrollButton.displayHeight;

--- a/src/ui/stats.js
+++ b/src/ui/stats.js
@@ -43,10 +43,20 @@ export class StatsScene extends Phaser.Scene {
 
         // Show stats
         this.enemiesKilledText = this.add
-            .text(20, 60, "Enemies killed: " + this.characterData.totalEnemiesKilled, FONTS.STATS)
+            .text(
+                20,
+                60,
+                "Enemies killed: " + this.characterData.totalEnemiesKilled,
+                FONTS.STATS
+            )
             .setDepth(3);
         this.timesClickedText = this.add
-            .text(20, 75, "Times clicked: " + this.characterData.timesClicked, FONTS.STATS)
+            .text(
+                20,
+                75,
+                "Times clicked: " + this.characterData.timesClicked,
+                FONTS.STATS
+            )
             .setDepth(3);
         this.damageByClickingText = this.add
             .text(


### PR DESCRIPTION
## Absolute path fixes
Currently there are two errors on the live server that are not reproducible locally, the lesser demon on the loading screen and dynamically importing the class of an item from the shop. The first error doesn't affect anything but the item import one breaks the shop.

After looking into it I think it's because these two paths are absolute instead of being relative so I've changed them to be such. The local version would be `localhost:8000/src/...` but the github pages one is `ethanvieira.github.io/rs-clicker/...` so I think it tries to access `ethanvieira.github.io/src/` instead of `ethanvieira.github.io/rs-clicker/src/`

I also ran prettier because I forgot to on the last commit of the last PR.