### PR TITLE
Fletching fixes (#7)

### DIFF
--- a/src/cookie-io.js
+++ b/src/cookie-io.js
@@ -10,6 +10,7 @@ function getDefaultData() {
 class CharacterData {
     characterData = getDefaultData();
     scene;
+    otherScenes = {}; // Hold dictionary of other scenes
 
     init(scene) {
         this.scene = scene;
@@ -142,10 +143,16 @@ class CharacterData {
             this.characterData.skills[skill] += xp;
             const curLevel = calcLevel(this.characterData.skills[skill]);
 
+            // Play level up sfx
             if (curLevel > prevLevel) {
-                const audioScene = this.scene.scene.get(CONSTANTS.SCENES.AUDIO);
+                const audioScene = this.getScene(CONSTANTS.SCENES.AUDIO);
                 audioScene.playSfx(skill + "-level-up");
             }
+
+            // Update xp text on dashboard
+            const dashboardScene = this.getScene(CONSTANTS.SCENES.DASHBOARD);
+            dashboardScene.skills.obj.updateSkillsText();
+
         } else {
             console.log("Error: setting invalid skill", skill, xp);
         }
@@ -204,6 +211,13 @@ class CharacterData {
         }
     }
 
+    getScene(sceneName) {
+        if (this.otherScenes[sceneName] == undefined) {
+            this.otherScenes[sceneName] = this.scene.scene.get(sceneName);
+        }
+        return this.otherScenes[sceneName];
+    }
+
     getCookies() {
         // Pull out first cookie
         let decodedCookies = decodeURIComponent(document.cookie).split(";");
@@ -236,9 +250,7 @@ class CharacterData {
     }
 
     reset() {
-        console.log("before reset:", this.characterData.audio);
         this.characterData = getDefaultData();
-        console.log("after:", this.characterData.audio);
     }
 }
 

--- a/src/default-data.js
+++ b/src/default-data.js
@@ -46,7 +46,7 @@ export const defaultData = {
         slayer: 0,
         farming: 0,
         construction: 0,
-        trapping: 0,
+        hunter: 0,
     },
     audio: [2, 2, 2], // BGM, SFX, Environment
     // Can be accessed with characterData[this.currentLevel].questCompleted, etc.

--- a/src/items/item.js
+++ b/src/items/item.js
@@ -147,6 +147,12 @@ export class Item extends ClickableObject {
         } else {
             this.numItems = num;
 
+            // Update saved data
+            characterData.setInventory(this.index, {
+                item: this.constructor.name,
+                count: this.numItems,
+            });
+
             // Update text
             if (this.numItemsText != undefined) {
                 let visualNum = "0";
@@ -154,16 +160,16 @@ export class Item extends ClickableObject {
 
                 // Set format/color based on the amount
                 switch (true) {
-                    case num < 1000:
+                    case num < 99999:
                         visualNum = num;
                         fillColor = "orange";
                         break;
-                    case num < 10000:
-                        visualNum = (num / 1000).toFixed(1) + " k";
+                    case num < 9999999:
+                        visualNum = (num / 1000).toFixed(1) + "k";
                         fillColor = "white";
                         break;
                     default:
-                        visualNum = (num / 1000000).toFixed(1) + " m";
+                        visualNum = (num / 1000000).toFixed(1) + "m";
                         fillColor = "green";
                         break;
                 }

--- a/src/items/tools/knife.js
+++ b/src/items/tools/knife.js
@@ -1,6 +1,7 @@
 import Tool from "../tool.js";
 import { CONSTANTS } from "../../constants/constants.js";
 import { getItemClass } from "../../utilities.js";
+import { characterData } from "../../cookie-io.js";
 
 export default class Knife extends Tool {
     // Text data
@@ -25,12 +26,12 @@ export default class Knife extends Tool {
             case "Logs":
                 className = "NormalShortbow";
                 numRequiredItems = 50;
-                xpGiven = 50;
+                xpGiven = 250;
                 break;
             case "Oak Logs":
                 className = "OakShortbow";
                 numRequiredItems = 50;
-                xpGiven = 100;
+                xpGiven = 500;
                 break;
             default:
                 console.log("Not a valid crafting combination.");
@@ -45,8 +46,7 @@ export default class Knife extends Tool {
             let newItem = await getItemClass(className, this.dashboard);
             if (this.dashboard.inventory.obj.addToInventory(newItem)) {
                 item.setNumItems(item.numItems - numRequiredItems);
-                this.scene.characterData.skills.fletching += xpGiven;
-                this.scene.skills.obj.updateSkillsText();
+                characterData.addSkillXp("fletching", xpGiven);
             }
         } else if (className != "" && item.numItems < numRequiredItems) {
             console.log(numRequiredItems, "are needed to craft that");

--- a/src/targets/enemy.js
+++ b/src/targets/enemy.js
@@ -293,7 +293,5 @@ export class Enemy extends Target {
             // Unarmed
             characterData.addSkillXp("attack", xpIncrease);
         }
-
-        this.scene.dashboard.skills.obj.updateSkillsText();
     }
 }

--- a/src/targets/resource.js
+++ b/src/targets/resource.js
@@ -34,8 +34,6 @@ export class Resource extends Target {
     onClick(clickValue) {}
 
     onCompletion() {
-        // Increase skill xp
         characterData.addSkillXp(this.skill, this.neededClicks);
-        this.scene.dashboard.skills.obj.updateSkillsText();
     }
 }

--- a/src/ui/inventory.js
+++ b/src/ui/inventory.js
@@ -77,9 +77,6 @@ export class Inventory {
                 // Update the item in the game
                 curItem.setNumItems(curItem.numItems + item.numItems);
 
-                // Update it in the cookies
-                playerItems[index].count += item.numItems;
-
                 // Delete old item
                 item.destroy();
 


### PR DESCRIPTION
* Updated fletching xp to be 5xp per log

* Fixed trapping -> hunter

* Items now handle updating their own count in saved data. Knife now uses correct current method of giving xp when fletching

* Moved execution of updateSkillsText() into cookie-io so you don't need to manually update the visuals after updating xp

* Removed unnecessary prints

* Fixed items stack font colors