### PR TITLE
Improve autoclicker performance

### DIFF
--- a/src/auto-clickers/auto-clicker.js
+++ b/src/auto-clickers/auto-clicker.js
@@ -72,9 +72,14 @@ export class AutoClicker {
 
     createText(isShop = false, x = 0, y = 0) {
         this.text = this.scrollWindow.add
-            .text(x, y, this.name + " x" + this.numberOwned.toString(), {
-                font: "16px runescape",
-            })
+            .text(
+                x,
+                y,
+                isShop ? this.name : this.name + " x" + this.numberOwned.toString(),
+                {
+                    font: "16px runescape",
+                }
+            )
             .setDepth(4)
             .setInteractive()
             .setOrigin(0, 0)

--- a/src/auto-clickers/auto-clicker.js
+++ b/src/auto-clickers/auto-clicker.js
@@ -15,6 +15,7 @@ export class AutoClicker {
     cost = 0;
     dps = 0;
     level = 0;
+    numberOwned = 0;
 
     // Scenes
     scrollWindow;
@@ -35,6 +36,7 @@ export class AutoClicker {
         this.level = data.level;
         this.name = data.name;
         this.dashboard = data.scene.scene.get(CONSTANTS.SCENES.DASHBOARD);
+        this.numberOwned = data.numberOwned;
 
         // Damage every .1 seconds
         this.damageInterval = 100;
@@ -50,24 +52,29 @@ export class AutoClicker {
 
     start(currentScene) {
         // Crafting levels (furnace, anvil, etc.) can't use auto clickers
-        if (currentScene.levelType != CONSTANTS.LEVEL_TYPE.CRAFTING && currentScene.levelType != CONSTANTS.LEVEL_TYPE.SMITHING) {
+        if (
+            currentScene.levelType != CONSTANTS.LEVEL_TYPE.CRAFTING &&
+            currentScene.levelType != CONSTANTS.LEVEL_TYPE.SMITHING
+        ) {
             this.timer.paused = false;
             this.currentScene = currentScene;
             this.stats = currentScene.stats;
 
-            this.stats.updateAutoClickerDPS(this.dps);
+            this.stats.updateAutoClickerDPS(this.dps * this.numberOwned);
         }
     }
 
     clickTarget() {
-        let damagePerTick = this.dps * (this.damageInterval / 1000);
+        let damagePerTick = this.dps * (this.damageInterval / 1000) * this.numberOwned;
         this.currentScene.clickCurrentTarget(damagePerTick);
         this.stats.updateAutoClickDamageStat(damagePerTick);
     }
 
     createText(isShop = false, x = 0, y = 0) {
         this.text = this.scrollWindow.add
-            .text(x, y, this.name, { font: "16px runescape" })
+            .text(x, y, this.name + " x" + this.numberOwned.toString(), {
+                font: "16px runescape",
+            })
             .setDepth(4)
             .setInteractive()
             .setOrigin(0, 0)
@@ -92,8 +99,7 @@ export class AutoClicker {
         if (this.dashboard == undefined) {
             this.dashboard = this.scrollWindow.scene.get(CONSTANTS.SCENES.DASHBOARD);
         }
-        let newMember = await getAutoclickerClass(this.name, this.dashboard);
-        this.dashboard.clan.addClanMember(newMember);
+        this.dashboard.clan.addClanMember(this.name);
     }
 
     examine(isShop) {

--- a/src/auto-clickers/bot.js
+++ b/src/auto-clickers/bot.js
@@ -9,7 +9,7 @@ export default class Bot extends AutoClicker {
             cost: 50,
             level: 1,
             dps: 1,
-            numberOwned: 1,
+            numberOwned: 0,
         });
     }
 }

--- a/src/auto-clickers/bot.js
+++ b/src/auto-clickers/bot.js
@@ -9,6 +9,7 @@ export default class Bot extends AutoClicker {
             cost: 50,
             level: 1,
             dps: 1,
+            numberOwned: 1,
         });
     }
 }

--- a/src/cookie-io.js
+++ b/src/cookie-io.js
@@ -1,11 +1,10 @@
 import { defaultData } from "./data/default-data.js";
-import { testAutoclickerPerformanceData } from "./data/test-autoclicker-performance-data.js";
 import { CONSTANTS, FONTS } from "./constants/constants.js";
 import * as Utilities from "./utilities.js";
 
 function getDefaultData() {
     // Reset data (deep copy)
-    return JSON.parse(JSON.stringify(testAutoclickerPerformanceData));
+    return JSON.parse(JSON.stringify(defaultData));
 }
 
 class CharacterData {

--- a/src/cookie-io.js
+++ b/src/cookie-io.js
@@ -99,11 +99,11 @@ class CharacterData {
         this.characterData.clan.name = name;
     }
 
-    addClanMember(obj) {
-        if (obj in this.characterData.clan.members) {
-            this.characterData.clan.members[obj]++;
+    addClanMember(memberName) {
+        if (memberName in this.characterData.clan.members) {
+            this.characterData.clan.members[memberName]++;
         } else {
-            this.characterData.clan.members[obj] = 1;
+            this.characterData.clan.members[memberName] = 1;
         }
     }
     getClanMembers() {

--- a/src/cookie-io.js
+++ b/src/cookie-io.js
@@ -1,10 +1,11 @@
 import { defaultData } from "./data/default-data.js";
+import { testAutoclickerPerformanceData } from "./data/test-autoclicker-performance-data.js";
 import { CONSTANTS, FONTS } from "./constants/constants.js";
 import * as Utilities from "./utilities.js";
 
 function getDefaultData() {
     // Reset data (deep copy)
-    return JSON.parse(JSON.stringify(defaultData));
+    return JSON.parse(JSON.stringify(testAutoclickerPerformanceData));
 }
 
 class CharacterData {
@@ -100,7 +101,11 @@ class CharacterData {
     }
 
     addClanMember(obj) {
-        this.characterData.clan.members.push(obj);
+        if (obj in this.characterData.clan.members) {
+            this.characterData.clan.members[obj]++;
+        } else {
+            this.characterData.clan.members[obj] = 1;
+        }
     }
     getClanMembers() {
         return this.characterData.clan.members;

--- a/src/data/test-autoclicker-performance-data.js
+++ b/src/data/test-autoclicker-performance-data.js
@@ -1,4 +1,4 @@
-export const defaultData = {
+export const testAutoclickerPerformanceData = {
     //hasCookies: false, // todo: maybe use this for tutorial?
     name: "You",
     gold: 0,
@@ -15,17 +15,16 @@ export const defaultData = {
         { item: "BronzePickaxe", count: 1 },
         { item: "Knife", count: 1 },
         { item: "Hammer", count: 1 },
-        { item: "Coin", count: 25 },
+        { item: "Coin", count: 69420 },
     ],
     equipment: {
         WEAPON: "",
     },
     clan: {
         name: "The Black Knights",
-        members: {},
+        members: { Bot: 100 },
     },
     attackStyle: 0,
-    autoRetaliate: true,
     // Skill XP
     skills: {
         attack: 0,
@@ -56,15 +55,15 @@ export const defaultData = {
     // Can be accessed with characterData[this.currentLevel].questCompleted, etc.
     levels: {
         TUTORIAL_ISLAND: {
-            questCompleted: false,
+            questCompleted: true,
             unlocked: true,
             enemiesKilled: {
                 giantRat: 0,
             },
         },
         LUMBRIDGE: {
-            questCompleted: false,
-            unlocked: false,
+            questCompleted: true,
+            unlocked: true,
             enemiesKilled: {
                 cow: 0,
                 goblin: 0,
@@ -74,45 +73,45 @@ export const defaultData = {
             // TODO: "enemiesKilled" makes things work nicely but isn't an accurate name here
             // Didn't want to implement the logic to discern between levels for this yet as the
             // Quest text will soon change anyway
-            questCompleted: false,
-            unlocked: false,
+            questCompleted: true,
+            unlocked: true,
             enemiesKilled: {
                 tree: 0,
             },
         },
         AL_KHARID_FURNACE: {
-            questCompleted: false,
-            unlocked: false,
+            questCompleted: true,
+            unlocked: true,
             enemiesKilled: {
                 bar: 0,
             },
         },
         VARROCK_ANVIL: {
-            questCompleted: false,
-            unlocked: false,
+            questCompleted: true,
+            unlocked: true,
             enemiesKilled: {
                 bronzeDagger: 0,
             },
         },
         VARROCK_MINE: {
-            questCompleted: false,
-            unlocked: false,
+            questCompleted: true,
+            unlocked: true,
             enemiesKilled: {
                 copperRock: 0,
                 tinRock: 0,
             },
         },
         VARROCK: {
-            questCompleted: false,
-            unlocked: false,
+            questCompleted: true,
+            unlocked: true,
             enemiesKilled: {
                 darkWizard: 0,
                 guard: 0,
             },
         },
         BARBARIAN_VILLAGE: {
-            questCompleted: false,
-            unlocked: false,
+            questCompleted: true,
+            unlocked: true,
             enemiesKilled: {
                 barbarian: 0,
             },

--- a/src/data/test-smithing-data.js
+++ b/src/data/test-smithing-data.js
@@ -6,7 +6,6 @@ export const testSmithingData = {
     timesClicked: 0,
     damageByClicking: 0,
     damageByAutoClick: 0,
-    numberOfAutoClickers: 0,
     questPoints: 0,
     inventory: [
         { item: "BronzeDagger", count: 1 },
@@ -26,8 +25,9 @@ export const testSmithingData = {
     },
     clan: {
         name: "The Black Knights",
-        members: [],
+        members: {},
     },
+    attackStyle: 0,
     // Skill XP
     skills: {
         attack: 0,

--- a/src/ui/panels/clan.js
+++ b/src/ui/panels/clan.js
@@ -94,7 +94,7 @@ export class Clan {
                 false,
                 startX,
                 startY + (this.clanMembers.length + 1) * yDiff
-            ); //TODO: add number to text
+            );
             member.setVisible(false);
             member.start(this.dashboard.currentScene);
             this.clanMembers.push(member);
@@ -129,7 +129,7 @@ export class Clan {
                     false,
                     startX,
                     startY + this.clanMembers.length * yDiff
-                ); //TODO: add number to text
+                );
                 this.clanMembers.push(member);
             }
 

--- a/src/ui/panels/clan.js
+++ b/src/ui/panels/clan.js
@@ -88,7 +88,7 @@ export class Clan {
         this.dashboard.currentScene.stats.resetAutoclickerDps();
         let savedClanMembers = characterData.getClanMembers();
         for (let memberName in savedClanMembers) {
-            let member = await getAutoclickerClass(memberName, this.scrollWindow);
+            const member = await getAutoclickerClass(memberName, this.scrollWindow);
             member.numberOwned = savedClanMembers[memberName];
             member.createText(
                 false,
@@ -114,7 +114,7 @@ export class Clan {
                 yDiff = 18;
 
             // Add new clan entry if new member else increment existing members
-            const member = this.clanMembers.find((member) => member.name === memberName);
+            let member = this.clanMembers.find((member) => member.name === memberName);
             if (!member) {
                 member = getAutoclickerClass(memberName, this.scrollWindow);
                 member.createText(
@@ -122,7 +122,7 @@ export class Clan {
                     startX,
                     startY + this.clanMembers.length * yDiff
                 );
-                this.clanMembers.push(newMember);
+                this.clanMembers.push(member);
             }
             member.numberOwned++;
 

--- a/src/ui/panels/clan.js
+++ b/src/ui/panels/clan.js
@@ -113,26 +113,18 @@ export class Clan {
                 startY = 280,
                 yDiff = 18;
 
-            // Add new clan entry if new member else increment existing member by one
-            const index = this.clanMembers.findIndex((member) => {
-                if (member.name === memberName) {
-                    return true;
-                }
-                return false;
-            });
-
-            if (index != -1) {
-                this.clanMembers[index].numberOwned++;
-            } else {
-                let member = getAutoclickerClass(memberName, this.scrollWindow);
+            // Add new clan entry if new member else increment existing members
+            const member = this.clanMembers.find((member) => member.name === memberName);
+            if (!member) {
+                member = getAutoclickerClass(memberName, this.scrollWindow);
                 member.createText(
                     false,
                     startX,
                     startY + this.clanMembers.length * yDiff
                 );
-                member.numberOwned = 1;
-                this.clanMembers.push(member);
+                this.clanMembers.push(newMember);
             }
+            member.numberOwned++;
 
             // Hide if clan tab is not selected
             let show = this.dashboard.currentPanel == CONSTANTS.PANEL.CLAN;

--- a/src/ui/panels/clan.js
+++ b/src/ui/panels/clan.js
@@ -87,10 +87,14 @@ export class Clan {
         // Reset dps counter before refreshing autoclickers
         this.dashboard.currentScene.stats.resetAutoclickerDps();
         let savedClanMembers = characterData.getClanMembers();
-        for (let index = 0; index < savedClanMembers.length; index++) {
-            let memberName = savedClanMembers[index];
+        for (let memberName in savedClanMembers) {
             let member = await getAutoclickerClass(memberName, this.scrollWindow);
-            member.createText(false, startX, startY + (index + 1) * yDiff);
+            member.numberOwned = savedClanMembers[memberName];
+            member.createText(
+                false,
+                startX,
+                startY + (this.clanMembers.length + 1) * yDiff
+            ); //TODO: add number to text
             member.setVisible(false);
             member.start(this.dashboard.currentScene);
             this.clanMembers.push(member);
@@ -99,9 +103,9 @@ export class Clan {
     }
 
     // Add clan member to list
-    addClanMember(member) {
+    addClanMember(memberName) {
         // Add to saved data
-        characterData.addClanMember(member.name);
+        characterData.addClanMember(memberName);
 
         // Add visuals if the dashboard is up
         if (this.dashboard.scene.isActive()) {
@@ -109,10 +113,25 @@ export class Clan {
                 startY = 280,
                 yDiff = 18;
 
-            // Add text to the list
-            let index = this.clanMembers.length;
-            member.createText(false, startX, startY + index * yDiff);
-            this.clanMembers.push(member);
+            // Add new clan entry if new member else increment existing member by one
+            const index = this.clanMembers.findIndex((member) => {
+                if (member.name === memberName) {
+                    return true;
+                }
+                return false;
+            });
+
+            if (index != -1) {
+                this.clanMembers[index].numberOwned++;
+            } else {
+                let member = getAutoclickerClass(memberName, this.scrollWindow);
+                member.createText(
+                    false,
+                    startX,
+                    startY + this.clanMembers.length * yDiff
+                ); //TODO: add number to text
+                this.clanMembers.push(member);
+            }
 
             // Hide if clan tab is not selected
             let show = this.dashboard.currentPanel == CONSTANTS.PANEL.CLAN;

--- a/src/ui/panels/clan.js
+++ b/src/ui/panels/clan.js
@@ -130,6 +130,7 @@ export class Clan {
                     startX,
                     startY + this.clanMembers.length * yDiff
                 );
+                member.numberOwned = 1;
                 this.clanMembers.push(member);
             }
 


### PR DESCRIPTION
* Allow only one object for each unique autoclicker in the list of active clan members
* Associate each unique clan member with the number owned
* Set dps to autoclicker.dps * number owned
* Add test data for testing autoclicker performance. Currently only includes 100 Bots. We will need to revisit when we have more autoclickers