### PR TITLE
add unlock-level and complete-quest commands

### DIFF
--- a/src/cookie-io.js
+++ b/src/cookie-io.js
@@ -195,6 +195,8 @@ class CharacterData {
         }
     }
 
+    // This sets the quest to be completed, unlocks associated levels, and gives quest points
+    // It does NOT give the actual KC that would be required to complete the quest normally
     setQuestCompleted(scene) {
         if (this.checkScene(scene)) {
             this.characterData.levels[scene].questCompleted = true;
@@ -207,7 +209,7 @@ class CharacterData {
                 ) {
                     this.characterData.levels[level].unlocked = true;
 
-                    // Write level up text to chat
+                    // Write unlock text to chat
                     const chatScene = this.getScene(CONSTANTS.SCENES.CHAT);
                     chatScene.writeText(
                         "Unlocked " + Utilities.prettyPrintConstant(level),
@@ -215,6 +217,8 @@ class CharacterData {
                     );
                 }
             }
+
+            this.addQuestPoints(this.getScene(CONSTANTS.SCENES[scene]).questPointAward);
         }
     }
 

--- a/src/data/commands.js
+++ b/src/data/commands.js
@@ -1,6 +1,7 @@
 import { dataMap } from "./test-data.js";
 import { characterData } from "../cookie-io.js";
-import { CONSTANTS } from "../constants/constants.js";
+import { CONSTANTS, FONTS } from "../constants/constants.js";
+import * as Utilities from "../utilities.js";
 
 export function load(dataName) {
     let chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
@@ -17,5 +18,52 @@ export function load(dataName) {
         chatScene.writeText("Loading: " + dataName);
     } else {
         chatScene.writeText('The test data "' + dataName + '" does not exist.');
+    }
+}
+
+export function unlockLevel(dataName) {
+    let chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
+
+    const constName = dataName.toUpperCase();
+    if (constName == "ALL") {
+        // unlock all levels
+        for (let level in characterData.characterData.levels) {
+            characterData.setQuestCompleted(CONSTANTS.PREREQUISITES[level]);
+        }
+    } else if (characterData.characterData.levels.hasOwnProperty(constName)) {
+        // unlock the level if it exists and start the newly unlocked scene
+
+        characterData.setQuestCompleted(CONSTANTS.PREREQUISITES[constName]);
+        chatScene.writeText(
+            "Unlocked level: " + Utilities.prettyPrintConstant(constName),
+            FONTS.ITEM_STATS
+        );
+
+        characterData
+            .getScene(characterData.getCurrentLevel())
+            .scene.start(CONSTANTS.SCENES[constName]);
+    } else {
+        chatScene.writeText('The level "' + dataName + '" does not exist.');
+    }
+}
+
+export function completeQuest(dataName) {
+    let chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
+
+    const constName = dataName.toUpperCase();
+    if (constName == "ALL") {
+        // complete all quests
+        for (let level in characterData.characterData.levels) {
+            characterData.setQuestCompleted(level);
+        }
+    } else if (characterData.characterData.levels.hasOwnProperty(constName)) {
+        // complete the quest for a level if it exists
+        characterData.setQuestCompleted(constName);
+        chatScene.writeText(
+            "Completed quest for level: " + Utilities.prettyPrintConstant(constName),
+            FONTS.ITEM_STATS
+        );
+    } else {
+        chatScene.writeText('The level "' + dataName + '" does not exist.');
     }
 }

--- a/src/data/commands.js
+++ b/src/data/commands.js
@@ -3,8 +3,78 @@ import { characterData } from "../cookie-io.js";
 import { CONSTANTS, FONTS } from "../constants/constants.js";
 import * as Utilities from "../utilities.js";
 
+export function handleCommand(commandStr) {
+    const words = commandStr.split(" ");
+
+    // remove "/" from command word
+    const command = words[0].substr(1).toLowerCase();
+
+    switch (command) {
+        case "load":
+            // Usage:
+            // /load name-of-test-data
+            // e.g.
+            // /load new-game
+            // /load all-levels
+
+            // ensure there is only one argument
+            if (words.length != 2) {
+                this.writeText("The load command only takes one argument.");
+                this.writeText("/load name-of-test-data");
+            } else {
+                load(words[1]);
+            }
+            break;
+
+        case "unlock-level":
+            // Usage:
+            // /unlock-level name-of-level
+            // if name-of-level is "all", unlock all levels
+            // e.g.
+            // /unlock-level varrock
+            // /unlock-level all
+
+            // ensure there is only one argument
+            if (words.length != 2) {
+                this.writeText("The unlock-level command only takes one argument.");
+                this.writeText("/unlock-level name-of-level");
+            } else {
+                unlockLevel(words[1]);
+            }
+            break;
+        case "unlock-song":
+        case "complete-quest":
+            // Usage:
+            // /complete-quest name-of-level
+            // if name-of-level is "all", complete all quests
+            // e.g.
+            // /complete-quest tutorial_island
+            // /complete-quest all
+
+            // ensure there is only one argument
+            if (words.length != 2) {
+                this.writeText("The complete-quest command only takes one argument.");
+                this.writeText("/complete-quest name-of-level");
+            } else {
+                completeQuest(words[1]);
+            }
+            break;
+
+        // TODO:
+        case "add-item":
+        case "add-member":
+        case "set-level":
+        case "set-xp":
+            this.writeText("The command: " + command + " is not yet implemented.");
+            break;
+
+        default:
+            this.writeText("Invalid command: " + command);
+    }
+}
+
 export function load(dataName) {
-    let chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
+    const chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
     // check if data exists
     if (dataMap.hasOwnProperty(dataName)) {
         // set current location to Tutorial Island to avoid any bugs of being
@@ -22,7 +92,7 @@ export function load(dataName) {
 }
 
 export function unlockLevel(dataName) {
-    let chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
+    const chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
 
     const constName = dataName.toUpperCase();
     if (constName == "ALL") {
@@ -48,7 +118,7 @@ export function unlockLevel(dataName) {
 }
 
 export function completeQuest(dataName) {
-    let chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
+    const chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
 
     const constName = dataName.toUpperCase();
     if (constName == "ALL") {

--- a/src/data/commands.js
+++ b/src/data/commands.js
@@ -4,6 +4,7 @@ import { CONSTANTS, FONTS } from "../constants/constants.js";
 import * as Utilities from "../utilities.js";
 
 export function handleCommand(commandStr) {
+    const chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
     const words = commandStr.split(" ");
 
     // remove "/" from command word
@@ -19,8 +20,8 @@ export function handleCommand(commandStr) {
 
             // ensure there is only one argument
             if (words.length != 2) {
-                this.writeText("The load command only takes one argument.");
-                this.writeText("/load name-of-test-data");
+                chatScene.writeText("The load command only takes one argument.");
+                chatScene.writeText("/load name-of-test-data");
             } else {
                 load(words[1]);
             }
@@ -36,8 +37,8 @@ export function handleCommand(commandStr) {
 
             // ensure there is only one argument
             if (words.length != 2) {
-                this.writeText("The unlock-level command only takes one argument.");
-                this.writeText("/unlock-level name-of-level");
+                chatScene.writeText("The unlock-level command only takes one argument.");
+                chatScene.writeText("/unlock-level name-of-level");
             } else {
                 unlockLevel(words[1]);
             }
@@ -53,8 +54,10 @@ export function handleCommand(commandStr) {
 
             // ensure there is only one argument
             if (words.length != 2) {
-                this.writeText("The complete-quest command only takes one argument.");
-                this.writeText("/complete-quest name-of-level");
+                chatScene.writeText(
+                    "The complete-quest command only takes one argument."
+                );
+                chatScene.writeText("/complete-quest name-of-level");
             } else {
                 completeQuest(words[1]);
             }
@@ -65,11 +68,11 @@ export function handleCommand(commandStr) {
         case "add-member":
         case "set-level":
         case "set-xp":
-            this.writeText("The command: " + command + " is not yet implemented.");
+            chatScene.writeText(`The command: '${command}' is not yet implemented.`);
             break;
 
         default:
-            this.writeText("Invalid command: " + command);
+            chatScene.writeText(`Invalid command: ${command}`);
     }
 }
 
@@ -85,9 +88,9 @@ export function load(dataName) {
         // load in the new data
         characterData.loadData(JSON.parse(JSON.stringify(dataMap[dataName])));
 
-        chatScene.writeText("Loading: " + dataName);
+        chatScene.writeText(`Loading: ${dataName}`);
     } else {
-        chatScene.writeText('The test data "' + dataName + '" does not exist.');
+        chatScene.writeText(`The test data '${dataName}' does not exist.`);
     }
 }
 
@@ -113,7 +116,7 @@ export function unlockLevel(dataName) {
             .getScene(characterData.getCurrentLevel())
             .scene.start(CONSTANTS.SCENES[constName]);
     } else {
-        chatScene.writeText('The level "' + dataName + '" does not exist.');
+        chatScene.writeText(`The level '${dataName}' does not exist.`);
     }
 }
 
@@ -134,6 +137,6 @@ export function completeQuest(dataName) {
             FONTS.ITEM_STATS
         );
     } else {
-        chatScene.writeText('The level "' + dataName + '" does not exist.');
+        chatScene.writeText(`The level '${dataName}' does not exist.`);
     }
 }

--- a/src/scenes/level.js
+++ b/src/scenes/level.js
@@ -181,7 +181,6 @@ export class LevelScene extends Phaser.Scene {
                 if (questCompleted) {
                     console.log("Quest complete!");
                     characterData.setQuestCompleted(this.currentLevel);
-                    characterData.addQuestPoints(this.questPointAward);
 
                     if (Math.random() < 0.5) {
                         this.audioScene.playSfx("quest-complete-1");

--- a/src/ui/chat-window.js
+++ b/src/ui/chat-window.js
@@ -3,7 +3,7 @@ import { ScrollWindow } from "./scroll-window.js";
 import { TextRow } from "./text-row.js";
 import { Button } from "./button.js";
 import { runOnLoad, capitalize } from "../utilities.js";
-import { load, unlockLevel, completeQuest } from "../data/commands.js";
+import { handleCommand } from "../data/commands.js";
 
 export class ChatScene extends Phaser.Scene {
     chatWindow;
@@ -463,81 +463,7 @@ export class ChatScene extends Phaser.Scene {
 
                     // check for commands
                     if (this.userMessage.text[0] == "/") {
-                        const words = this.userMessage.text.split(" ");
-
-                        // remove "/" from command word
-                        const command = words[0].substr(1).toLowerCase();
-
-                        switch (command) {
-                            case "load":
-                                // Usage:
-                                // /load name-of-test-data
-                                // e.g.
-                                // /load new-game
-                                // /load all-levels
-
-                                // ensure there is only one argument
-                                if (words.length != 2) {
-                                    this.writeText(
-                                        "The load command only takes one argument."
-                                    );
-                                    this.writeText("/load name-of-test-data");
-                                } else {
-                                    load(words[1]);
-                                }
-                                break;
-
-                            case "unlock-level":
-                                // Usage:
-                                // /unlock-level name-of-level
-                                // if name-of-level is "all", unlock all levels
-                                // e.g.
-                                // /unlock-level varrock
-                                // /unlock-level all
-
-                                // ensure there is only one argument
-                                if (words.length != 2) {
-                                    this.writeText(
-                                        "The unlock-level command only takes one argument."
-                                    );
-                                    this.writeText("/unlock-level name-of-level");
-                                } else {
-                                    unlockLevel(words[1]);
-                                }
-                                break;
-                            case "unlock-song":
-                            case "complete-quest":
-                                // Usage:
-                                // /complete-quest name-of-level
-                                // if name-of-level is "all", complete all quests
-                                // e.g.
-                                // /complete-quest tutorial_island
-                                // /complete-quest all
-
-                                // ensure there is only one argument
-                                if (words.length != 2) {
-                                    this.writeText(
-                                        "The complete-quest command only takes one argument."
-                                    );
-                                    this.writeText("/complete-quest name-of-level");
-                                } else {
-                                    completeQuest(words[1]);
-                                }
-                                break;
-
-                            // TODO:
-                            case "add-item":
-                            case "add-member":
-                            case "set-level":
-                            case "set-xp":
-                                this.writeText(
-                                    "The command: " + command + " is not yet implemented."
-                                );
-                                break;
-
-                            default:
-                                this.writeText("Invalid command: " + command);
-                        }
+                        handleCommand(this.userMessage.text);
                     } else {
                         // write to chat window
                         this.writeStrings(

--- a/src/ui/chat-window.js
+++ b/src/ui/chat-window.js
@@ -3,7 +3,7 @@ import { ScrollWindow } from "./scroll-window.js";
 import { TextRow } from "./text-row.js";
 import { Button } from "./button.js";
 import { runOnLoad, capitalize } from "../utilities.js";
-import { load } from "../data/commands.js";
+import { load, unlockLevel, completeQuest } from "../data/commands.js";
 
 export class ChatScene extends Phaser.Scene {
     chatWindow;
@@ -487,10 +487,45 @@ export class ChatScene extends Phaser.Scene {
                                 }
                                 break;
 
-                            // TODO:
                             case "unlock-level":
+                                // Usage:
+                                // /unlock-level name-of-level
+                                // if name-of-level is "all", unlock all levels
+                                // e.g.
+                                // /unlock-level varrock
+                                // /unlock-level all
+
+                                // ensure there is only one argument
+                                if (words.length != 2) {
+                                    this.writeText(
+                                        "The unlock-level command only takes one argument."
+                                    );
+                                    this.writeText("/unlock-level name-of-level");
+                                } else {
+                                    unlockLevel(words[1]);
+                                }
+                                break;
                             case "unlock-song":
                             case "complete-quest":
+                                // Usage:
+                                // /complete-quest name-of-level
+                                // if name-of-level is "all", complete all quests
+                                // e.g.
+                                // /complete-quest tutorial_island
+                                // /complete-quest all
+
+                                // ensure there is only one argument
+                                if (words.length != 2) {
+                                    this.writeText(
+                                        "The complete-quest command only takes one argument."
+                                    );
+                                    this.writeText("/complete-quest name-of-level");
+                                } else {
+                                    completeQuest(words[1]);
+                                }
+                                break;
+
+                            // TODO:
                             case "add-item":
                             case "add-member":
                             case "set-level":


### PR DESCRIPTION
Usage:
* /unlock-level name-of-level
   if name-of-level is "all", unlock all levels
   e.g.
   /unlock-level varrock
   /unlock-level all

* /complete-quest name-of-level
  if name-of-level is "all", complete all quests
  e.g.
  /complete-quest tutorial_island
  /complete-quest all