### PR TITLE
add set-level and set-xp commands

### DIFF
--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -66,6 +66,11 @@ export const CONSTANTS = {
         CLAN: "CLAN",
         ATTACK_STYLE: "ATTACK_STYLE",
     },
+    LIMITS: {
+        MAX_LEVEL: 99,
+        MAX_XP: 200_000_000,
+        XP_FOR_99: 13_034_431,
+    },
     UTILS: {
         MILLIS_IN_YEAR: 365 * 24 * 60 * 60 * 1000,
     },

--- a/src/cookie-io.js
+++ b/src/cookie-io.js
@@ -152,7 +152,11 @@ class CharacterData {
     addSkillXp(skill, xp) {
         if (this.characterData.skills[skill] != undefined) {
             const prevLevel = Utilities.calcLevel(this.characterData.skills[skill]);
-            this.characterData.skills[skill] += xp;
+            this.characterData.skills[skill] = Math.min(
+                this.characterData.skills[skill] + xp,
+                CONSTANTS.LIMITS.MAX_XP
+            );
+
             const curLevel = Utilities.calcLevel(this.characterData.skills[skill]);
 
             // Play level up sfx
@@ -177,6 +181,46 @@ class CharacterData {
             console.log("Error: setting invalid skill", skill, xp);
         }
     }
+
+    setSkillXp(skill, xp) {
+        if (this.characterData.skills[skill] != undefined) {
+            this.characterData.skills[skill] = Math.min(xp, CONSTANTS.LIMITS.MAX_XP);
+
+            // Update xp text on dashboard
+            const dashboardScene = this.getScene(CONSTANTS.SCENES.DASHBOARD);
+            dashboardScene.skills.updateSkillsText();
+        } else {
+            console.log("Error: setting invalid skill", skill);
+        }
+    }
+
+    setXpForAllSkills(xp) {
+        for (let skill in this.characterData.skills) {
+            this.setSkillXp(skill, xp);
+        }
+    }
+
+    setSkillLevel(skill, level) {
+        if (this.characterData.skills[skill] != undefined) {
+            this.characterData.skills[skill] = Math.min(
+                Utilities.calcXpForLevel(level),
+                CONSTANTS.LIMITS.XP_FOR_99
+            );
+
+            // Update xp text on dashboard
+            const dashboardScene = this.getScene(CONSTANTS.SCENES.DASHBOARD);
+            dashboardScene.skills.updateSkillsText();
+        } else {
+            console.log("Error: setting invalid skill", skill);
+        }
+    }
+
+    setLevelForAllSkills(level) {
+        for (let skill in this.characterData.skills) {
+            this.setSkillLevel(skill, level);
+        }
+    }
+
     getSkillXp(skill) {
         if (this.characterData.skills[skill] != undefined) {
             return this.characterData.skills[skill];
@@ -185,6 +229,7 @@ class CharacterData {
             return 0;
         }
     }
+
     getSkills() {
         return this.characterData.skills;
     }

--- a/src/data/commands.js
+++ b/src/data/commands.js
@@ -20,7 +20,7 @@ export function handleCommand(commandStr) {
 
             // ensure there is only one argument
             if (words.length != 2) {
-                chatScene.writeText("The load command only takes one argument.");
+                chatScene.writeText("The load command takes one argument.");
                 chatScene.writeText("/load name-of-test-data");
             } else {
                 load(words[1]);
@@ -37,7 +37,7 @@ export function handleCommand(commandStr) {
 
             // ensure there is only one argument
             if (words.length != 2) {
-                chatScene.writeText("The unlock-level command only takes one argument.");
+                chatScene.writeText("The unlock-level command takes one argument.");
                 chatScene.writeText("/unlock-level name-of-level");
             } else {
                 unlockLevel(words[1]);
@@ -53,7 +53,7 @@ export function handleCommand(commandStr) {
 
             // ensure there is only one argument
             if (words.length != 2) {
-                chatScene.writeText("The unlock-song command only takes one argument.");
+                chatScene.writeText("The unlock-song command takes one argument.");
                 chatScene.writeText("/unlock-song name-of-song");
             } else {
                 unlockSong(words[1]);
@@ -69,20 +69,50 @@ export function handleCommand(commandStr) {
 
             // ensure there is only one argument
             if (words.length != 2) {
-                chatScene.writeText(
-                    "The complete-quest command only takes one argument."
-                );
+                chatScene.writeText("The complete-quest command takes one argument.");
                 chatScene.writeText("/complete-quest name-of-level");
             } else {
                 completeQuest(words[1]);
             }
             break;
 
+        case "set-level":
+            // Usage:
+            // /set-level name-of-skill level
+            // if name-of-skill is "all", set all skills to the given level
+            // if level is "max", set the skill to 99
+            // e.g.
+            // /set-level fletching 72
+            // /set-level all max
+
+            // ensure there are exactly 2 arguments
+            if (words.length != 3) {
+                chatScene.writeText("The set-level command takes two arguments.");
+                chatScene.writeText("/set-level name-of-skill level");
+            } else {
+                setLevel(words[1], words[2]);
+            }
+            break;
+        case "set-xp":
+            // Usage:
+            // /set-xp name-of-skill xp
+            // if name-of-skill is "all", set all skills to the given xp
+            // if xp is "max", set the xp to 200,000,000
+            // e.g.
+            // /set-xp fletching 236674
+            // /set-xp all max
+
+            // ensure there are exactly 2 arguments
+            if (words.length != 3) {
+                chatScene.writeText("The set-xp command takes two arguments.");
+                chatScene.writeText("/set-xp name-of-skill xp");
+            } else {
+                setXp(words[1], words[2]);
+            }
+            break;
         // TODO:
         case "add-item":
         case "add-member":
-        case "set-level":
-        case "set-xp":
             chatScene.writeText(`The command: '${command}' is not yet implemented.`);
             break;
 
@@ -187,5 +217,61 @@ export function unlockSong(songName) {
         // The music scene will write the unlock text for us
     } else {
         chatScene.writeText(`The song '${songName}' does not exist.`);
+    }
+}
+
+export function setLevel(skillName, level) {
+    const chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
+    const constName = skillName.toLowerCase();
+    const isMax = level.toLowerCase() == "max";
+    const levelInt = parseInt(level);
+
+    if (!isMax && levelInt == NaN) {
+        chatScene.writeText(`Cannot set a skill's level to a non-integer value.`);
+        return;
+    }
+
+    if (constName == "all") {
+        if (isMax) {
+            characterData.setLevelForAllSkills(CONSTANTS.LIMITS.MAX_LEVEL);
+        } else {
+            characterData.setLevelForAllSkills(levelInt);
+        }
+    } else if (characterData.getSkills().hasOwnProperty(constName)) {
+        if (isMax) {
+            characterData.setSkillLevel(CONSTANTS.LIMITS.MAX_LEVEL);
+        } else {
+            characterData.setSkillLevel(constName, levelInt);
+        }
+    } else {
+        chatScene.writeText(`The skill '${skillName}' does not exist.`);
+    }
+}
+
+export function setXp(skillName, xp) {
+    const chatScene = characterData.getScene(CONSTANTS.SCENES.CHAT);
+    const constName = skillName.toLowerCase();
+    const isMax = xp.toLowerCase() == "max";
+    const xpInt = parseInt(xp);
+
+    if (!isMax && xpInt == NaN) {
+        chatScene.writeText(`Cannot set a skill's xp to a non-integer value.`);
+        return;
+    }
+
+    if (constName == "all") {
+        if (isMax) {
+            characterData.setXpForAllSkills(CONSTANTS.LIMITS.MAX_XP);
+        } else {
+            characterData.setXpForAllSkills(xpInt);
+        }
+    } else if (characterData.getSkills().hasOwnProperty(constName)) {
+        if (isMax) {
+            characterData.setSkillXp(CONSTANTS.LIMITS.MAX_XP);
+        } else {
+            characterData.setSkillXp(constName, xpInt);
+        }
+    } else {
+        chatScene.writeText(`The skill '${skillName}' does not exist.`);
     }
 }

--- a/src/ui/panels/skills.js
+++ b/src/ui/panels/skills.js
@@ -163,7 +163,10 @@ export class Skills {
             const skills = characterData.getSkills();
 
             for (let skill in skills) {
-                let level = calcLevel(skills[skill]);
+                let level = Math.min(
+                    calcLevel(skills[skill]),
+                    CONSTANTS.LIMITS.MAX_LEVEL
+                );
                 this.skillText[skill].text = level;
                 this.skillText[skill + "Bottom"].text = level;
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -23,6 +23,14 @@ export function calcRemainingXp(xp) {
     return levelUpXp - xp + 1;
 }
 
+export function calcXpForLevel(lv) {
+    let xp = 0;
+    for (let x = 1; x < lv; x++) {
+        xp += x + 300 * Math.pow(2, (x + 1) / 7);
+    }
+    return 0.25 * xp;
+}
+
 var itemClasses = {};
 export async function getItemClass(itemName, scene) {
     let itemClass = itemClasses[itemName];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12479219/188350614-8dbc970e-5164-4003-b04d-8375f7d42eeb.png)

* There is a future task to resize the xp box to hold the long xp numbers [here](https://trello.com/c/Kfo5PeEh/166-resize-skill-xp-box-on-skill-hover-to-fit-the-length-of-the-numbers-shown)
* Usage:
            /set-level/set-xp name-of-skill level/xp
            if name-of-skill is "all", set all skills to the given level/xp
            if level/xp is "max", set the skill/xp to 99/200,000,000
            e.g.
            /set-level/set-xp fletching 72
            /set-level/set-xp all max